### PR TITLE
修正：BookmarksテーブルをCommentsテーブルに変更、それに伴う追加

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,4 @@
-class Bookmark < ApplicationRecord
+class Comment < ApplicationRecord
   # アソシエーション設定
   belongs_to :user
   belongs_to :library

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,6 +4,6 @@ class Comment < ApplicationRecord
   belongs_to :library
 
   #バリデーション設定
-  validates :user_id, uniqueness: { scope: :library_id}
+  validates :body, presence: true, length: { maximum: 65_535 }
 
 end

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -1,6 +1,6 @@
 class Library < ApplicationRecord
   belongs_to :administration
-  has_many :bookmarks, dependent: :destroy
+  has_many :comments, dependent: :destroy
   has_many :libraries_services, dependent: :destroy
   # 中間テーブルを通してサービステーブルとアソシエーションを結ぶ
   has_many :services, through: :libraries_services

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   # 以下アソシエーション設定
-  has_many :bookmarks, dependent: :destroy
-  has_many :bookmark_libraries, through: :bookmarks, source: :library
+  has_many :comments, dependent: :destroy
 
   # 以下バリデーション
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze #変数に正規表現を代入（emailのformatで使用）

--- a/db/migrate/20220905005526_change_bookmarks_to_comments.rb
+++ b/db/migrate/20220905005526_change_bookmarks_to_comments.rb
@@ -1,0 +1,5 @@
+class ChangeBookmarksToComments < ActiveRecord::Migration[6.1]
+  def change
+    rename_table :bookmarks, :comments
+  end
+end

--- a/db/migrate/20220905012609_add_column_to_comments.rb
+++ b/db/migrate/20220905012609_add_column_to_comments.rb
@@ -1,0 +1,5 @@
+class AddColumnToComments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :comments, :body, :text, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_25_021607) do
+ActiveRecord::Schema.define(version: 2022_09_05_005526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,14 +22,14 @@ ActiveRecord::Schema.define(version: 2022_08_25_021607) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "bookmarks", force: :cascade do |t|
+  create_table "comments", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "library_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["library_id"], name: "index_bookmarks_on_library_id"
-    t.index ["user_id", "library_id"], name: "index_bookmarks_on_user_id_and_library_id", unique: true
-    t.index ["user_id"], name: "index_bookmarks_on_user_id"
+    t.index ["library_id"], name: "index_comments_on_library_id"
+    t.index ["user_id", "library_id"], name: "index_comments_on_user_id_and_library_id", unique: true
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "libraries", force: :cascade do |t|
@@ -76,8 +76,8 @@ ActiveRecord::Schema.define(version: 2022_08_25_021607) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  add_foreign_key "bookmarks", "libraries"
-  add_foreign_key "bookmarks", "users"
+  add_foreign_key "comments", "libraries"
+  add_foreign_key "comments", "users"
   add_foreign_key "libraries_services", "libraries"
   add_foreign_key "libraries_services", "services"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_05_005526) do
+ActiveRecord::Schema.define(version: 2022_09_05_012609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2022_09_05_005526) do
     t.bigint "library_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "body", null: false
     t.index ["library_id"], name: "index_comments_on_library_id"
     t.index ["user_id", "library_id"], name: "index_comments_on_user_id_and_library_id", unique: true
     t.index ["user_id"], name: "index_comments_on_user_id"


### PR DESCRIPTION
## 実装内容
 - `Bookmarksテーブル`を`Commentsテーブル`にrenameした後、`Bookmarks`の表記になっているアソシエーション等を修正いたしました。
  19473f34dbab63cca8eb64f7792e9772e6efcaed
 - `Comments テーブル`に`bodyカラム`を追加し、`NotNull制約`を設定、それによるバリデーションを設定いたしました。
  af5307b76486030061ac3fe960ad7387ddb1a1c8

上記の変更、ご確認お願いします。